### PR TITLE
feat: Solve multiple feedback

### DIFF
--- a/dapps/reports/src/pages/api/password-protect.ts
+++ b/dapps/reports/src/pages/api/password-protect.ts
@@ -11,6 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (PASSWORD_PROTECT === password) {
     const cookie = serialize('login', 'true', {
       path: '/',
+      expires: new Date(new Date().getTime() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
       httpOnly: true
     })
     res.setHeader('Set-Cookie', cookie)

--- a/dapps/reports/src/utils/format.ts
+++ b/dapps/reports/src/utils/format.ts
@@ -1,6 +1,8 @@
 import numbro from 'numbro'
 
 export const formatCurrency = (value: number, mantissa = 0) => {
+  if (value === 0) return '-'
+
   return numbro(value).formatCurrency({
     spaceSeparated: false,
     mantissa,

--- a/dapps/reports/src/views/sections/BalanceOverviewItems/TableType.tsx
+++ b/dapps/reports/src/views/sections/BalanceOverviewItems/TableType.tsx
@@ -31,7 +31,7 @@ const TableType = (props: TableTypeProps) => {
               Wallet
             </TableHeadCellCustom>
             <TableHeadCellCustom sx={{ width: '20%' }} align="left">
-              Grand total
+              Total
             </TableHeadCellCustom>
           </TableRow>
         </TableHead>
@@ -49,42 +49,38 @@ const TableType = (props: TableTypeProps) => {
                   {row['Token Category']}
                 </TableCellCustom>
                 <TableCellCustom sx={{ width: '20%' }} align="left">
-                  {formatCurrency(row['Farming Funds'] || 0)}
+                  {formatCurrency(Math.round(row['Farming Funds'] || 0))}
                 </TableCellCustom>
                 <TableCellCustom sx={{ width: '20%' }} align="left">
-                  {formatCurrency(row['Unclaimed Rewards'] || 0)}
+                  {formatCurrency(Math.round(row['Unclaimed Rewards'] || 0))}
                 </TableCellCustom>
                 <TableCellCustom sx={{ width: '20%' }} align="left">
-                  {formatCurrency(row['Wallet'] || 0)}
+                  {formatCurrency(Math.round(row['Wallet'] || 0))}
                 </TableCellCustom>
                 <TableCellCustom sx={{ width: '20%' }} align="left">
-                  {formatCurrency(row['Total'] || 0)}
+                  {formatCurrency(Math.round(row['Total'] || 0))}
                 </TableCellCustom>
               </TableRow>
             )
           })}
           <TableRow>
-            <TableEmptyCellCustom />
-            <TableEmptyCellCustom />
-            <TableEmptyCellCustom />
-            <TableEmptyCellCustom />
-            <TableEmptyCellCustom />
+            <TableEmptyCellCustom colSpan={5} />
           </TableRow>
           <TableRow>
             <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-              Grand total
+              Total
             </TableFooterCellCustom>
             <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-              {formatCurrency(dataFooterType['Farming Funds'] || 0)}
+              {formatCurrency(Math.round(dataFooterType['Farming Funds'] || 0))}
             </TableFooterCellCustom>
             <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-              {formatCurrency(dataFooterType['Unclaimed Rewards'] || 0)}
+              {formatCurrency(Math.round(dataFooterType['Unclaimed Rewards'] || 0))}
             </TableFooterCellCustom>
             <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-              {formatCurrency(dataFooterType['Wallet'] || 0)}
+              {formatCurrency(Math.round(dataFooterType['Wallet'] || 0))}
             </TableFooterCellCustom>
             <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-              {formatCurrency(dataFooterType['Total'] || 0)}
+              {formatCurrency(Math.round(dataFooterType['Total'] || 0))}
             </TableFooterCellCustom>
           </TableRow>
         </TableBody>

--- a/dapps/reports/src/views/sections/FarmingFundsItems/FundsContainer.tsx
+++ b/dapps/reports/src/views/sections/FarmingFundsItems/FundsContainer.tsx
@@ -136,7 +136,7 @@ const FundsContainer = (props: FundsContainerProps) => {
     <PaperSection
       id="Farming funds and results"
       title="Farming funds and results"
-      subTitle="Farming funds/results by protocol"
+      subTitle="Farming funds/results by position"
       helpInfo="Farming funds, % allocation and results per position.  Detail by rewards and fees/rebasing/pool token variation. Swap results."
       filter={filter}
     >

--- a/dapps/reports/src/views/sections/FarmingFundsItems/ResultsContainer.tsx
+++ b/dapps/reports/src/views/sections/FarmingFundsItems/ResultsContainer.tsx
@@ -133,7 +133,7 @@ const ResultsContainer = (props: ResultsContainerProps) => {
   const isFilterActive = blockchainFilter || protocolFilter
 
   return (
-    <PaperSection subTitle={'Farming results detail by protocol'} filter={filter}>
+    <PaperSection subTitle="Farming results detail by position" filter={filter}>
       {fundsDetails.length === 0 && !isFilterActive ? (
         <EmptyData />
       ) : (

--- a/dapps/reports/src/views/sections/FarmingFundsItems/TableFunds.tsx
+++ b/dapps/reports/src/views/sections/FarmingFundsItems/TableFunds.tsx
@@ -7,13 +7,20 @@ import TableFooterCellCustom from '@karpatkey-monorepo/shared/components/Table/T
 import TableHeadCellCustom from '@karpatkey-monorepo/shared/components/Table/TableHeadCellCustom'
 import BoxWrapperColumn from '@karpatkey-monorepo/shared/components/Wrappers/BoxWrapperColumn'
 import BoxWrapperRow from '@karpatkey-monorepo/shared/components/Wrappers/BoxWrapperRow'
-import { Box, Table, TableBody, TableContainer, TableHead, TableRow } from '@mui/material'
+import { Box, Table, TableBody, TableContainer, TableHead, TableRow, styled } from '@mui/material'
 import * as React from 'react'
 
 interface TableFundsProps {
   funds: any
   totals: any
 }
+
+const BoxWrapper = styled(BoxWrapperColumn)({
+  minWidth: 'max-content',
+  width: '125px',
+  maxWidth: '100%',
+  alignItems: 'flex-end'
+})
 
 const TableFunds = (props: TableFundsProps) => {
   const { funds, totals } = props
@@ -68,19 +75,12 @@ const TableFunds = (props: TableFundsProps) => {
                         </BoxWrapperColumn>
                       </TableCellCustom>
                       <TableCellCustom sx={{ width: '20%' }} align="left">
-                        <BoxWrapperColumn
-                          sx={{
-                            minWidth: 'max-content',
-                            width: '125px',
-                            maxWidth: '100%',
-                            alignItems: 'flex-end'
-                          }}
-                        >
+                        <BoxWrapper>
                           {formatCurrency(Math.round(row.funds || 0))}
                           <CustomTypography variant="tableCellSubData">
                             {formatPercentage(row.allocation / 100)}
                           </CustomTypography>
-                        </BoxWrapperColumn>
+                        </BoxWrapper>
                       </TableCellCustom>
                       <TableCellCustom sx={{ width: '20%' }} align="left">
                         {formatCurrency(Math.round(row.unclaimed || 0))}
@@ -131,16 +131,7 @@ const TableFunds = (props: TableFundsProps) => {
                     Total
                   </TableFooterCellCustom>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-                    <BoxWrapperColumn
-                      sx={{
-                        minWidth: 'max-content',
-                        width: '125px',
-                        maxWidth: '100%',
-                        alignItems: 'flex-end'
-                      }}
-                    >
-                      {formatCurrency(Math.round(totals?.fundsTotal || 0))}
-                    </BoxWrapperColumn>
+                    <BoxWrapper>{formatCurrency(Math.round(totals?.fundsTotal || 0))}</BoxWrapper>
                   </TableFooterCellCustom>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
                     {formatCurrency(Math.round(totals?.unclaimedTotal || 0))}

--- a/dapps/reports/src/views/sections/FarmingFundsItems/TableFunds.tsx
+++ b/dapps/reports/src/views/sections/FarmingFundsItems/TableFunds.tsx
@@ -127,14 +127,20 @@ const TableFunds = (props: TableFundsProps) => {
                 )}
 
                 <TableRow>
-                  <TableFooterCellCustom sx={{ width: '20%' }} align="left">
+                  <TableFooterCellCustom colSpan={2} align="left">
                     Total
                   </TableFooterCellCustom>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-                    {' '}
-                  </TableFooterCellCustom>
-                  <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-                    {formatCurrency(Math.round(totals?.fundsTotal || 0))}
+                    <BoxWrapperColumn
+                      sx={{
+                        minWidth: 'max-content',
+                        width: '125px',
+                        maxWidth: '100%',
+                        alignItems: 'flex-end'
+                      }}
+                    >
+                      {formatCurrency(Math.round(totals?.fundsTotal || 0))}
+                    </BoxWrapperColumn>
                   </TableFooterCellCustom>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
                     {formatCurrency(Math.round(totals?.unclaimedTotal || 0))}

--- a/dapps/reports/src/views/sections/FarmingFundsItems/TableFunds.tsx
+++ b/dapps/reports/src/views/sections/FarmingFundsItems/TableFunds.tsx
@@ -76,17 +76,17 @@ const TableFunds = (props: TableFundsProps) => {
                             alignItems: 'flex-end'
                           }}
                         >
-                          {formatCurrency(row.funds || 0)}
+                          {formatCurrency(Math.round(row.funds || 0))}
                           <CustomTypography variant="tableCellSubData">
                             {formatPercentage(row.allocation / 100)}
                           </CustomTypography>
                         </BoxWrapperColumn>
                       </TableCellCustom>
                       <TableCellCustom sx={{ width: '20%' }} align="left">
-                        {formatCurrency(row.unclaimed) || 0}
+                        {formatCurrency(Math.round(row.unclaimed || 0))}
                       </TableCellCustom>
                       <TableCellCustom sx={{ width: '20%' }} align="left">
-                        {formatCurrency(row.results) || 0}
+                        {formatCurrency(Math.round(row.results || 0))}
                       </TableCellCustom>
                     </TableRow>
                   )
@@ -128,19 +128,19 @@ const TableFunds = (props: TableFundsProps) => {
 
                 <TableRow>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-                    Grand total
+                    Total
                   </TableFooterCellCustom>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
                     {' '}
                   </TableFooterCellCustom>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-                    {formatCurrency(totals?.fundsTotal || 0)}
+                    {formatCurrency(Math.round(totals?.fundsTotal || 0))}
                   </TableFooterCellCustom>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-                    {formatCurrency(totals?.unclaimedTotal || 0)}
+                    {formatCurrency(Math.round(totals?.unclaimedTotal || 0))}
                   </TableFooterCellCustom>
                   <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-                    {formatCurrency(totals?.resultsTotal || 0)}
+                    {formatCurrency(Math.round(totals?.resultsTotal || 0))}
                   </TableFooterCellCustom>
                 </TableRow>
               </>

--- a/dapps/reports/src/views/sections/FarmingFundsItems/TableResults.tsx
+++ b/dapps/reports/src/views/sections/FarmingFundsItems/TableResults.tsx
@@ -116,7 +116,7 @@ const TableResults = (props: TableResultsProps) => {
               )}
               <TableRow>
                 <TableFooterCellCustom sx={{ width: '20%' }} align="left">
-                  Grand total
+                  Total
                 </TableFooterCellCustom>
                 <TableFooterCellCustom sx={{ width: '20%' }} align="left">
                   {' '}

--- a/dapps/reports/src/views/sections/Summary.tsx
+++ b/dapps/reports/src/views/sections/Summary.tsx
@@ -41,7 +41,7 @@ const Summary = (props: SummaryProps) => {
           <DynamicInfoCard title="Total funds" value={formatCurrency(totalFunds)} />
           <DynamicInfoCard
             title="Capital utilization"
-            value={formatPercentage(capitalUtilization)}
+            value={formatPercentage(capitalUtilization, 1)}
           />
           <DynamicInfoCard title="Farming results" value={formatCurrency(farmingResults)} />
           <DynamicInfoCard

--- a/dapps/reports/src/views/sections/Summary.tsx
+++ b/dapps/reports/src/views/sections/Summary.tsx
@@ -45,7 +45,7 @@ const Summary = (props: SummaryProps) => {
           />
           <DynamicInfoCard title="Farming results" value={formatCurrency(farmingResults)} />
           <DynamicInfoCard
-            title="Global ROI"
+            title="Global APY"
             value={formatPercentage(globalROI)}
             helpInfo="This value is calculated as (1+(Farming Results / Initial Balance at Final Prices))^12-1."
           />

--- a/dapps/reports/src/views/sections/TreasuryVariation.tsx
+++ b/dapps/reports/src/views/sections/TreasuryVariation.tsx
@@ -6,7 +6,7 @@ import PaperSection from '@karpatkey-monorepo/shared/components/PaperSection'
 import TabPanel from '@karpatkey-monorepo/shared/components/TabPanel'
 import { FILTER_DAO, MONTHS } from '@karpatkey-monorepo/shared/config/constants'
 import { getDAO } from '@karpatkey-monorepo/shared/utils'
-import HelpCenterIcon from '@mui/icons-material/HelpCenter'
+import InfoIcon from '@mui/icons-material/Info'
 import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Tooltip from '@mui/material/Tooltip'
@@ -49,7 +49,7 @@ const TreasuryVariation = (props: TreasuryVariationProps) => {
       <ToggleButton disableRipple value={1} sx={{ textTransform: 'none' }}>
         Year to period
         <Tooltip title={helpText} sx={{ ml: 1 }}>
-          <HelpCenterIcon />
+          <InfoIcon />
         </Tooltip>
       </ToggleButton>
     </ToggleButtonGroup>

--- a/shared/components/InfoCard.tsx
+++ b/shared/components/InfoCard.tsx
@@ -2,7 +2,7 @@ import CustomTypography from '@karpatkey-monorepo/shared/components/CustomTypogr
 import Paper from '@karpatkey-monorepo/shared/components/Paper'
 import BoxWrapperColumn from '@karpatkey-monorepo/shared/components/Wrappers/BoxWrapperColumn'
 import BoxWrapperRow from '@karpatkey-monorepo/shared/components/Wrappers/BoxWrapperRow'
-import HelpCenterIcon from '@mui/icons-material/HelpCenter'
+import InfoIcon from '@mui/icons-material/Info'
 import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
 
@@ -32,7 +32,7 @@ const InfoCard = ({ title, value, helpInfo }: InfoCardProps) => {
               }
               sx={{ ml: 1, cursor: 'pointer' }}
             >
-              <HelpCenterIcon sx={{ fontSize: 24 }} />
+              <InfoIcon sx={{ fontSize: 24, cursor: 'pointer' }} />
             </Tooltip>
           ) : null}
         </BoxWrapperRow>

--- a/shared/components/PaperSection.tsx
+++ b/shared/components/PaperSection.tsx
@@ -4,7 +4,7 @@ import Paper from '@karpatkey-monorepo/shared/components/Paper'
 import BoxWrapperColumn from '@karpatkey-monorepo/shared/components/Wrappers/BoxWrapperColumn'
 import BoxWrapperRow from '@karpatkey-monorepo/shared/components/Wrappers/BoxWrapperRow'
 import { slugify } from '@karpatkey-monorepo/shared/utils'
-import HelpCenterIcon from '@mui/icons-material/HelpCenter'
+import InfoIcon from '@mui/icons-material/Info'
 import { Divider } from '@mui/material'
 import Tooltip from '@mui/material/Tooltip'
 import * as React from 'react'
@@ -38,7 +38,7 @@ const PaperSection = (props: PaperSectionProps) => {
                 }
                 sx={{ ml: 1, cursor: 'pointer' }}
               >
-                <HelpCenterIcon sx={{ fontSize: 40 }} />
+                <InfoIcon sx={{ fontSize: 40, cursor: 'pointer' }} />
               </Tooltip>
             ) : null}
           </BoxWrapperRow>


### PR DESCRIPTION
# Summary

Balance overview section:
- If the user filter by "Blockchain", the data should be sorted by Grand Total, the token category with the largest amount at the top and from there down in order.
- If possible, where the value is 0, display a "-" instead of "$0".
- To both tables of both views instead of "Grand Total" put "Total".

Farming Funds and Results section:
- Modify the titles of the tables by the indicated ones.
- "Farming funds/results by protocol" change to "Farming funds/results by position".
- "Farming results detail by protocol" change to "Farming results detail by position".
- In the table "Farming funds/results by protocol" the grand total of farming funds is not aligned with the data in the table. ALIGN
- To both tables instead of "Grand Total" put "Total".

Summary:
- Capital Utilization show a single decimal place

Globally:
- Change Help Icon for the InfoIcon

# Issue addressed

Close #739 

# Test Plan

### Manual Testing

- [ ] 1.

- [ ] 2.

- [ ] 3.

### Visual changes

_Screenshots_ or _loom_

### Deployment

- [ ] Any special requests before or after deploying

# Reviewer

- [ ] Changes work as expected (according to requirements)
- [ ] Tested that complete user journey works as expected
- [ ] Manually tested
- [ ] Unit/acceptance specs
