### PR TITLE
feat: In the "Total funds by token category" section put the negative value at the bottom

### DIFF
--- a/dapps/reports/src/views/Homepage.tsx
+++ b/dapps/reports/src/views/Homepage.tsx
@@ -67,6 +67,7 @@ const HomepageContent = (props: ReportProps) => {
         fundsByTokenCategory={fundsByTokenCategory}
         fundsByType={fundsByType}
         fundsByBlockchain={fundsByBlockchain}
+        balanceOverviewType={balanceOverviewType}
       />
       <BalanceOverview
         balanceOverviewType={balanceOverviewType}

--- a/dapps/reports/src/views/sections/Summary.tsx
+++ b/dapps/reports/src/views/sections/Summary.tsx
@@ -4,6 +4,7 @@ import BoxWrapperColumn from '@karpatkey-monorepo/shared/components/Wrappers/Box
 import BoxWrapperRow from '@karpatkey-monorepo/shared/components/Wrappers/BoxWrapperRow'
 import dynamic from 'next/dynamic'
 import * as React from 'react'
+import CustomTypography from '@karpatkey-monorepo/shared/components/CustomTypography'
 
 const DynamicPieChart = dynamic(
   () => import('@karpatkey-monorepo/reports/src/components/Charts/Pie')
@@ -19,6 +20,7 @@ interface SummaryProps {
   fundsByTokenCategory: any[]
   fundsByType: any[]
   fundsByBlockchain: any[]
+  balanceOverviewType: any[]
 }
 
 const Summary = (props: SummaryProps) => {
@@ -29,8 +31,11 @@ const Summary = (props: SummaryProps) => {
     farmingResults,
     fundsByTokenCategory,
     fundsByType,
-    fundsByBlockchain
+    fundsByBlockchain,
+    balanceOverviewType
   } = props
+
+  const negativeTotalValue = balanceOverviewType.find((item) => item.Total < 0)
 
   return (
     <AnimatePresenceWrapper>
@@ -49,13 +54,24 @@ const Summary = (props: SummaryProps) => {
           />
         </BoxWrapperRow>
         <BoxWrapperRow sx={{ justifyContent: 'space-between' }}>
-          <DynamicPieChart
-            data={fundsByTokenCategory}
-            title="Total funds by token category"
-            dataKey="funds"
-            width={450}
-            height={400}
-          />
+          <BoxWrapperColumn sx={{ alignItems: 'center' }} gap={4}>
+            <DynamicPieChart
+              data={fundsByTokenCategory}
+              title="Total funds by token category"
+              dataKey="funds"
+              width={450}
+              height={400}
+            />
+            {negativeTotalValue && (
+              <CustomTypography
+                variant={'body2'}
+                color="textSecondary"
+                sx={{ fontFamily: 'IBM Plex Sans', fontSize: 12, fontStyle: 'italic' }}
+              >
+                Negative balance = {formatCurrency(negativeTotalValue?.Total)}
+              </CustomTypography>
+            )}
+          </BoxWrapperColumn>
           <DynamicPieChart
             data={fundsByBlockchain}
             title="Total funds by blockchain"

--- a/shared/utils/mappers/treasuryVariation.ts
+++ b/shared/utils/mappers/treasuryVariation.ts
@@ -52,7 +52,7 @@ export const getTreasuryVariationForThePeriod = (data: any) => {
     })
 
   const haveValueFinalBalance = rows.find((row: any) => row.key === 4)
-  if (!haveValueFinalBalance) {
+  if (!haveValueFinalBalance && rows.length > 0) {
     const total = rows.reduce(
       (accumulator: number, currentValue: { funds: number }) => accumulator + currentValue.funds,
       0


### PR DESCRIPTION
# Summary

- Fix the problem with the waterfall and the emptiness of some values
- In the "Total funds by token category" section put the negative value at the bottom

# Issue addressed

Close #763

# Test Plan

### Manual Testing

- [ ] 1.

- [ ] 2.

- [ ] 3.

### Visual changes

_Screenshots_ or _loom_

### Deployment

- [ ] Any special requests before or after deploying

# Reviewer

- [ ] Changes work as expected (according to requirements)
- [ ] Tested that complete user journey works as expected
- [ ] Manually tested
- [ ] Unit/acceptance specs
